### PR TITLE
[Feature/#40] 검색페이지 api 연동

### DIFF
--- a/src/api/store/common.ts
+++ b/src/api/store/common.ts
@@ -27,4 +27,5 @@ export interface ErrorResponse {
   code: string;
   message: string;
   status: number;
+  errors: [];
 }

--- a/src/api/store/storeApi.ts
+++ b/src/api/store/storeApi.ts
@@ -10,6 +10,9 @@ interface StoreListParams {
 }
 interface StoreSearchParams {
   name: string;
+  page?: number;
+  size?: number;
+  sort?: string;
 }
 
 export interface StoreUser {
@@ -82,7 +85,7 @@ export const getStoreList = async (
 
 export const getSeachList = async (
   params: StoreSearchParams,
-): Promise<SuccessOkResponse<StoreUser[]>> => {
+): Promise<SuccessOkResponse<StoreListResponse>> => {
   const url = getApiUrl('/users/stores/search/name');
   const response = await axios.get(url, {
     params,

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -20,7 +20,7 @@ export const Navigation: VFC = () => {
         <NavLink to={`/${PATH.search}`}>
           <NavigationSearchIcon />
         </NavLink>
-        <NavLink to={`/${PATH.Reservation}`}>
+        <NavLink to={`/${PATH.reservation}`}>
           {({ isActive }) => <NavigationNotificationIcon active={isActive} />}
         </NavLink>
         <NavLink to={`/${PATH.myPage}`}>

--- a/src/components/reservation/ReservationList/ReservationList.tsx
+++ b/src/components/reservation/ReservationList/ReservationList.tsx
@@ -12,7 +12,7 @@ export const ReservationList = () => {
     ReservationTime: '15:00-18:00',
   };
   return (
-    <Link to={`/${PATH.ReservationDetail}`}>
+    <Link to={`/${PATH.reservationDetail}`}>
       <ReservationItem
         src={Reservation.src}
         ReservationName={Reservation.ReservationName}

--- a/src/components/store/SearchBar/SearchBar.tsx
+++ b/src/components/store/SearchBar/SearchBar.tsx
@@ -1,39 +1,69 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getSeachList } from 'api/store/storeApi';
 import { InputResetIcon } from 'components/form/atoms/InputResetIcon';
 import { Spinner } from 'components/layout/Spinner';
 import {
   ResetbtnWrapper,
+  ResponseMessage,
   SearchBarContainer,
   SearchBarWrapper,
   SearchInput,
   SearchInputWrapper,
 } from 'components/store/SearchBar/SearchBar.styled';
 import { StoreItem } from 'components/store/StoreItem';
-import { ErrorMessage } from 'components/store/storeList/AllList/AllList.styled';
 import { SearchContext } from 'context/SearchContext';
 import { BackButtonIcon } from 'pages/LoginPage/LoginPage.styled';
 import { useContext, useState } from 'react';
+import InfiniteScroll from 'react-infinite-scroller';
 import { Link, useNavigate } from 'react-router-dom';
-import type { StoreUser } from 'api/store/storeApi';
+import type { ErrorResponse } from 'api/store/common';
+import type { StoreListResponse, StoreUser } from 'api/store/storeApi';
 import type { VFC } from 'common/utils/types';
 
 import type { ChangeEvent, KeyboardEvent } from 'react';
 
 export const SearchBar: VFC = () => {
   const searchContext = useContext(SearchContext);
+  const [query, setQuery] = useState('');
 
   if (!searchContext) {
     throw new Error('SearchBar must be used within a SearchProvider');
   }
+  const { searchValue, setSearchValue } = searchContext;
 
-  const { searchValue, setSearchValue, searchResults, setSearchResults } =
-    searchContext;
+  const getSeachData = async ({ pageParam = 1 }) => {
+    const resData = await getSeachList({
+      page: pageParam,
+      size: 15,
+      name: searchValue,
+    });
+    return resData.result;
+  };
 
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<null | string>(null);
+  const { isLoading, isError, data, fetchNextPage, hasNextPage } =
+    useInfiniteQuery<StoreListResponse, ErrorResponse>({
+      queryKey: ['SearchData', query],
+      queryFn: ({ pageParam = 1 }) => getSeachData({ pageParam }),
+      getNextPageParam: (lastPage) => {
+        if (lastPage.totalPage > lastPage.curPage) {
+          return lastPage.curPage + 1;
+        }
+        return undefined;
+      },
+    });
+
+  const handleSearch = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setQuery(searchValue);
+    }
+  };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
+  };
+
+  const handleLoadMore = (): void => {
+    fetchNextPage();
   };
 
   const handleValueResetClick = () => {
@@ -46,22 +76,15 @@ export const SearchBar: VFC = () => {
     navigate(-1);
   };
 
-  const handleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && searchValue.length > 0) {
-      try {
-        setLoading(true);
-        const resData = await getSeachList({ name: searchValue });
-        setSearchResults(resData.result);
-        setLoading(false);
-      } catch (err) {
-        setError('서버에서 데이터를 받아오지 못했습니다');
-        setLoading(false);
-      }
-    }
-  };
-
-  if (loading) {
+  if (isLoading) {
     return <Spinner />;
+  }
+  let stores: StoreUser[] = [];
+  if (data) {
+    for (let i = 0; i < data.pages.length; i++) {
+      const page = data.pages[i];
+      stores = [...stores, ...page.storeResponseList];
+    }
   }
 
   return (
@@ -73,7 +96,7 @@ export const SearchBar: VFC = () => {
             placeholder='검색어를 입력하세요'
             onChange={handleChange}
             value={searchValue}
-            onKeyDown={handleKeyDown}
+            onKeyDown={handleSearch}
           />
           {searchValue.length > 0 && (
             <ResetbtnWrapper>
@@ -82,21 +105,26 @@ export const SearchBar: VFC = () => {
           )}
         </SearchInputWrapper>
       </SearchBarWrapper>
-      {error && <ErrorMessage>{error}</ErrorMessage>}
-      {loading ? (
-        <Spinner />
-      ) : (
-        searchResults.map((store: StoreUser) => (
-          <Link key={store.id} to={`/storeDetail/${store.id}`}>
-            <StoreItem
-              key={store.id}
-              src={store.mainImage}
-              storeName={store.name}
-              introduction={store.introduction}
-            />
-          </Link>
-        ))
-      )}
+      <InfiniteScroll loadMore={handleLoadMore} hasMore={hasNextPage}>
+        {isError ? (
+          <ResponseMessage>
+            요청 중 오류가 발생했습니다. 다시 시도해주세요.
+          </ResponseMessage>
+        ) : stores.length === 0 ? (
+          <ResponseMessage>검색 결과가 없습니다.</ResponseMessage>
+        ) : (
+          stores.map((store) => (
+            <Link key={store.id} to={`/storeDetail/${store.id}`}>
+              <StoreItem
+                key={store.id}
+                src={store.mainImage}
+                storeName={store.name}
+                introduction={store.introduction}
+              />
+            </Link>
+          ))
+        )}
+      </InfiniteScroll>
     </SearchBarContainer>
   );
 };

--- a/src/components/store/SearchBar/SearchBar.tsx
+++ b/src/components/store/SearchBar/SearchBar.tsx
@@ -66,8 +66,7 @@ export const SearchBar: VFC = () => {
   };
 
   const handleValueResetClick = () => {
-    setQuery('');
-    setSearchParams({});
+    setInputValue('');
   };
 
   let stores: StoreUser[] = [];

--- a/src/components/store/SearchBar/SearchBar.tsx
+++ b/src/components/store/SearchBar/SearchBar.tsx
@@ -14,7 +14,7 @@ import {
 import { StoreItem } from 'components/store/StoreItem';
 import { SearchContext } from 'context/SearchContext';
 import { BackButtonIcon } from 'pages/LoginPage/LoginPage.styled';
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
 import { Link, useNavigate } from 'react-router-dom';
 import type { ErrorResponse } from 'api/store/common';
@@ -25,13 +25,18 @@ import type { ChangeEvent, KeyboardEvent } from 'react';
 
 export const SearchBar: VFC = () => {
   const searchContext = useContext(SearchContext);
-  const [query, setQuery] = useState('');
 
   if (!searchContext) {
     throw new Error('SearchBar must be used within a SearchProvider');
   }
-  const { searchValue, setSearchValue, searchResults, setSearchResults } =
-    searchContext;
+  const {
+    searchValue,
+    setSearchValue,
+    searchResults,
+    setSearchResults,
+    query,
+    setQuery,
+  } = searchContext;
 
   const getSeachData = async ({ pageParam = 1 }) => {
     const resData = await getSeachList({

--- a/src/components/store/SearchBar/SearchBar.tsx
+++ b/src/components/store/SearchBar/SearchBar.tsx
@@ -2,7 +2,6 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getSeachList } from 'api/store/storeApi';
 import { InputResetIcon } from 'components/form/atoms/InputResetIcon';
 import { Spinner } from 'components/layout/Spinner';
-
 import {
   ResetbtnWrapper,
   ResponseMessage,
@@ -12,11 +11,10 @@ import {
   SearchInputWrapper,
 } from 'components/store/SearchBar/SearchBar.styled';
 import { StoreItem } from 'components/store/StoreItem';
-import { SearchContext } from 'context/SearchContext';
 import { BackButtonIcon } from 'pages/LoginPage/LoginPage.styled';
-import { useContext } from 'react';
+import { useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroller';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import type { ErrorResponse } from 'api/store/common';
 import type { StoreListResponse, StoreUser } from 'api/store/storeApi';
 import type { VFC } from 'common/utils/types';
@@ -24,25 +22,15 @@ import type { VFC } from 'common/utils/types';
 import type { ChangeEvent, KeyboardEvent } from 'react';
 
 export const SearchBar: VFC = () => {
-  const searchContext = useContext(SearchContext);
-
-  if (!searchContext) {
-    throw new Error('SearchBar must be used within a SearchProvider');
-  }
-  const {
-    searchValue,
-    setSearchValue,
-    searchResults,
-    setSearchResults,
-    query,
-    setQuery,
-  } = searchContext;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [inputValue, setInputValue] = useState(searchParams.get('query') || '');
+  const [query, setQuery] = useState(searchParams.get('query') || '');
 
   const getSeachData = async ({ pageParam = 1 }) => {
     const resData = await getSeachList({
       page: pageParam,
       size: 15,
-      name: searchValue,
+      name: query,
     });
     return resData.result;
   };
@@ -50,32 +38,27 @@ export const SearchBar: VFC = () => {
   const { isLoading, isError, data, fetchNextPage, hasNextPage } =
     useInfiniteQuery<StoreListResponse, ErrorResponse>({
       queryKey: ['SearchData', query],
-      queryFn: getSeachData,
-      staleTime: 500000,
+      queryFn: ({ pageParam = 1 }) => getSeachData({ pageParam }),
       getNextPageParam: (lastPage) => {
         if (lastPage.totalPage > lastPage.curPage) {
           return lastPage.curPage + 1;
         }
         return undefined;
       },
-      onSuccess: (resData) => {
-        let stores: StoreUser[] = [];
-        for (let i = 0; i < resData.pages.length; i++) {
-          const page = resData.pages[i];
-          stores = [...stores, ...page.storeResponseList];
-        }
-        setSearchResults(stores);
-      },
+      enabled: query.length > 0,
     });
+
+  const navigate = useNavigate();
 
   const handleSearch = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      setQuery(searchValue);
+      setQuery(inputValue);
+      navigate(`?query=${inputValue}`, { replace: true });
     }
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearchValue(e.target.value);
+    setInputValue(e.target.value);
   };
 
   const handleLoadMore = (): void => {
@@ -83,10 +66,17 @@ export const SearchBar: VFC = () => {
   };
 
   const handleValueResetClick = () => {
-    setSearchValue('');
+    setQuery('');
+    setSearchParams({});
   };
 
-  const navigate = useNavigate();
+  let stores: StoreUser[] = [];
+  if (data) {
+    for (let i = 0; i < data.pages.length; i++) {
+      const page = data.pages[i];
+      stores = [...stores, ...page.storeResponseList];
+    }
+  }
 
   const handleButtonClick = () => {
     navigate(-1);
@@ -100,10 +90,10 @@ export const SearchBar: VFC = () => {
           <SearchInput
             placeholder='검색어를 입력하세요'
             onChange={handleChange}
-            value={searchValue}
+            value={inputValue}
             onKeyDown={handleSearch}
           />
-          {searchValue.length > 0 && (
+          {query.length > 0 && (
             <ResetbtnWrapper>
               <InputResetIcon onClick={handleValueResetClick} />
             </ResetbtnWrapper>
@@ -115,14 +105,12 @@ export const SearchBar: VFC = () => {
           <ResponseMessage>
             요청 중 오류가 발생했습니다. 다시 시도해주세요.
           </ResponseMessage>
-        ) : searchResults.length === 0 ? (
-          isLoading ? (
-            <Spinner />
-          ) : (
-            <ResponseMessage>검색 결과가 없습니다.</ResponseMessage>
-          )
+        ) : isLoading ? (
+          <Spinner />
+        ) : stores.length === 0 ? (
+          <ResponseMessage>검색 결과가 없습니다.</ResponseMessage>
         ) : (
-          searchResults.map((store) => (
+          stores.map((store) => (
             <Link key={store.id} to={`/storeDetail/${store.id}`}>
               <StoreItem
                 key={store.id}

--- a/src/context/SearchContext.tsx
+++ b/src/context/SearchContext.tsx
@@ -12,6 +12,8 @@ interface SearchContextProps {
   setSearchValue: React.Dispatch<React.SetStateAction<string>>;
   searchResults: StoreUser[];
   setSearchResults: React.Dispatch<React.SetStateAction<StoreUser[]>>;
+  query: string;
+  setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 export const SearchContext = createContext<SearchContextProps | undefined>(
   undefined,
@@ -28,14 +30,26 @@ export const SearchProvider: VFC<SearchProviderProps> = ({ children }) => {
     return sessionData ? JSON.parse(sessionData) : [];
   });
 
+  const [query, setQuery] = useState<string>(() => {
+    const sessionData = sessionStorage.getItem('query');
+    return sessionData ? JSON.parse(sessionData) : '';
+  });
+
   useEffect(() => {
     sessionStorage.setItem('searchValue', JSON.stringify(searchValue));
     sessionStorage.setItem('searchResults', JSON.stringify(searchResults));
   }, [searchValue, searchResults]);
 
   const value = useMemo(
-    () => ({ searchValue, setSearchValue, searchResults, setSearchResults }),
-    [searchValue, searchResults],
+    () => ({
+      searchValue,
+      setSearchValue,
+      searchResults,
+      setSearchResults,
+      query,
+      setQuery,
+    }),
+    [searchValue, searchResults, query],
   );
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,15 +20,15 @@ root.render(
   <React.StrictMode>
     <ThemeProvider theme={myTheme}>
       <FormProvider>
-        <QueryClientProvider client={queryclient}>
-          <GoogleOAuthProvider clientId='169343984623-lq9lvl7ir9nusto7qalvdv4i667t7cdo.apps.googleusercontent.com'>
-            <SearchProvider>
+        <SearchProvider>
+          <QueryClientProvider client={queryclient}>
+            <GoogleOAuthProvider clientId='169343984623-lq9lvl7ir9nusto7qalvdv4i667t7cdo.apps.googleusercontent.com'>
               <App />
               <GlobalStyles />
-            </SearchProvider>
-          </GoogleOAuthProvider>
-          <ReactQueryDevtools initialIsOpen={false} />
-        </QueryClientProvider>
+            </GoogleOAuthProvider>
+            <ReactQueryDevtools initialIsOpen={false} />
+          </QueryClientProvider>
+        </SearchProvider>
       </FormProvider>
     </ThemeProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## 기획 및 구현한 내용

검색페이지 리엑트쿼리, 페이지네이션 적용했습니다


## 테스트 방법

1 .env파일 생성 후 노션에 있는 환경변수 복붙
2 yarn install && yarn start
3 /search 접속 후 검색어 입력 후 엔터 리스트 15개 이상 노출시 페이지 네이션 유무 확인

기존에 다른페이지에서 돌아와도 검색 결과 값 유지는 그대로 적용했습니다.


## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [ ] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [ ] 이슈 상태를 업데이트 함.
