### PR TITLE
[Feature/#62] 좌석 사용가능하도록 spaceId, chairId 연결

### DIFF
--- a/src/api/store/common.ts
+++ b/src/api/store/common.ts
@@ -91,7 +91,6 @@ export interface StoreListParams {
   size?: number;
   sort?: string;
 }
-
 export interface StoreSearchParams {
   name: string;
   page?: number;

--- a/src/components/store/SeatInfoTab/SeatInfoTab.tsx
+++ b/src/components/store/SeatInfoTab/SeatInfoTab.tsx
@@ -15,6 +15,7 @@ import { SpaceList } from 'components/store/SeatInfoTab/components/SpaceList';
 import { StoreLayout } from 'components/store/SeatInfoTab/components/StoreLayout';
 
 import { useEffect, useState } from 'react';
+import { useReservationStore } from 'store/reservationStore';
 import type { SpaceType, StoreDetaillResponse } from 'api/store/common';
 
 import type { VFC } from 'common/utils/types';
@@ -28,6 +29,9 @@ interface SeatInfoTabProps {
  * 좌석정보 탭을 클릭했을 때 하단에 보여줄 컴포넌트
  */
 export const SeatInfoTab: VFC<SeatInfoTabProps> = ({ storeId }) => {
+  const setStoreId = useReservationStore((state) => state.setStoreId);
+  setStoreId(storeId);
+
   const { data: spaceList, isLoading } = useGetSpaceList(storeId);
   const [currentSpace, setCurrentSpace] = useState<SpaceType | null>(null);
 

--- a/src/components/store/reservation/Intent/Intent.tsx
+++ b/src/components/store/reservation/Intent/Intent.tsx
@@ -72,9 +72,11 @@ export const Intent = () => {
   const setCustomContent = useReservationStore(
     (state) => state.setCustomContent,
   );
+  const storeId = useReservationStore((state) => state.storeId);
   const startSchedule = useReservationStore((state) => state.startSchedule);
   const endSchedule = useReservationStore((state) => state.endSchedule);
   const storeChairId = useReservationStore((state) => state.storeChairId);
+  const storeSpaceId = useReservationStore((state) => state.storeSpaceId);
   const customUtilizationContents = useReservationStore(
     (state) => state.customUtilizationContents,
   );
@@ -145,7 +147,7 @@ export const Intent = () => {
     const getRequestData = async () => {
       try {
         const params: GetRequestInformationParams = {
-          storeId: '55',
+          storeId: String(storeId),
         };
         const data = await getRequestInformation(params);
         if (!data.result) {
@@ -193,7 +195,7 @@ export const Intent = () => {
 
       if (from === 'SeatBooking' || from === 'SeatUseNow') {
         const params: SeatScheduleParams = {
-          storeChairId: 58,
+          storeChairId,
           startSchedule,
           endSchedule,
           customUtilizationContents,
@@ -203,7 +205,7 @@ export const Intent = () => {
         )(params);
       } else if (from === 'SpaceBooking' || from === 'SpaceUseNow') {
         const params: SpaceScheduleParams = {
-          storeSpaceId: 58,
+          storeSpaceId,
           startSchedule,
           endSchedule,
           customUtilizationContents,
@@ -215,7 +217,7 @@ export const Intent = () => {
         throw new Error('Invalid "from" type');
       }
 
-      navigate(PATH.storeDetail); // TODO: 해당 스토어디테일 페이지 이동
+      navigate(`/${PATH.storeDetail}/${storeId}`, { replace: true });
     } catch (error) {
       return null;
     }

--- a/src/components/store/reservation/seatReservation/SeatReservationTab/SeatReservationTab.tsx
+++ b/src/components/store/reservation/seatReservation/SeatReservationTab/SeatReservationTab.tsx
@@ -7,6 +7,7 @@ import { SeatBooking } from 'components/store/reservation/seatReservation/SeatBo
 
 import { SeatUseNow } from 'components/store/reservation/seatReservation/SeatUseNow';
 import { useEffect, useState } from 'react';
+import { useReservationStore } from 'store/reservationStore';
 import type { ReservationParams } from 'api/reservation/common';
 
 import type { VFC } from 'common/utils/types';
@@ -26,6 +27,7 @@ export const SeatReservationTab: VFC<ReservationTabProps> = ({
   onChange,
   selectedDate,
 }) => {
+  const storeChairId = useReservationStore((state) => state.storeChairId);
   const [reservations, setReservations] = useState<ReservationProps[]>([]);
   const handleValueChange = (newValue: number) => {
     onChange(newValue);
@@ -44,14 +46,14 @@ export const SeatReservationTab: VFC<ReservationTabProps> = ({
         const params: ReservationParams = {
           'reservation-date-and-time': kstIsoString,
         };
-        const response = await getSeatReservations(58, params);
+        const response = await getSeatReservations(storeChairId, params);
         setReservations(response.result.allReservationsForSeatAndDate);
       } catch (error) {
         return null;
       }
     };
     getReservationTime();
-  }, [selectedDate]);
+  }, [selectedDate, storeChairId]);
   return (
     <>
       <Tabs value={value} onChange={handleValueChange}>

--- a/src/components/store/reservation/spaceReservation/Booking/SpaceBooking.tsx
+++ b/src/components/store/reservation/spaceReservation/Booking/SpaceBooking.tsx
@@ -1,3 +1,4 @@
+import { PATH } from 'common/utils/constants';
 import { Button } from 'components/form/atoms/Button';
 import { TimeSlot } from 'components/store/reservation/TimeSlot';
 import {
@@ -107,7 +108,10 @@ export const SpaceBooking: React.FC<BookingProps> = ({
     const startISOTime = getKSTFormattedTime(startTimeStr);
     const endISOTime = getKSTFormattedTime(endTimeStr);
     setSchedule(startISOTime, endISOTime);
-    navigate('/intent', { state: { from: 'SpaceBooking' } });
+    navigate(`/${PATH.intent}`, {
+      state: { from: 'SpaceBooking' },
+      replace: true,
+    });
   };
 
   const isTimeSlotReserved = (time: string) => {

--- a/src/components/store/reservation/spaceReservation/SpaceReservationTab/SpaceReservationTab.tsx
+++ b/src/components/store/reservation/spaceReservation/SpaceReservationTab/SpaceReservationTab.tsx
@@ -6,6 +6,7 @@ import { Tabs } from 'components/common/tab/Tabs';
 import { SpaceBooking } from 'components/store/reservation/spaceReservation/Booking';
 import { SpaceUseNow } from 'components/store/reservation/spaceReservation/SpaceUseNow';
 import { useEffect, useState } from 'react';
+import { useReservationStore } from 'store/reservationStore';
 import type { ReservationParams } from 'api/reservation/common';
 import type { VFC } from 'common/utils/types';
 
@@ -23,6 +24,7 @@ export const SpaceReservationTab: VFC<ReservationTabProps> = ({
   onChange,
   selectedDate,
 }) => {
+  const storeSpaceId = useReservationStore((state) => state.storeSpaceId);
   const [reservations, setReservations] = useState<ReservationProps[]>([]);
   const handleValueChange = (newValue: number) => {
     onChange(newValue);
@@ -41,14 +43,14 @@ export const SpaceReservationTab: VFC<ReservationTabProps> = ({
         const params: ReservationParams = {
           'reservation-date-and-time': kstIsoString,
         };
-        const response = await getSpaceReservations(58, params);
+        const response = await getSpaceReservations(storeSpaceId, params);
         setReservations(response.result.allReservationsForSeatAndDate);
       } catch (error) {
         return null;
       }
     };
     getReservationTime();
-  }, [selectedDate]);
+  }, [selectedDate, storeSpaceId]);
   return (
     <>
       <Tabs value={value} onChange={handleValueChange}>

--- a/src/store/reservationStore.ts
+++ b/src/store/reservationStore.ts
@@ -1,25 +1,33 @@
 import { create } from 'zustand';
 
 interface ReservationState {
+  storeId: number;
   storeChairId: number;
+  storeSpaceId: number;
   startSchedule: string;
   endSchedule: string;
   customUtilizationContents: {
     fieldId: number;
     content: string[];
   }[];
+  setStoreId: (id: number) => void;
   setChairId: (id: number) => void;
+  setSpaceId: (id: number) => void;
   setSchedule: (start: string, end: string) => void;
   setCustomContent: (fieldId: number, content: string[]) => void;
 }
 
 export const useReservationStore = create<ReservationState>((set) => ({
+  storeId: 1,
   storeChairId: 1,
+  storeSpaceId: 1,
   startSchedule: '',
   endSchedule: '',
   customUtilizationContents: [],
 
   setChairId: (id) => set({ storeChairId: id }),
+  setSpaceId: (id) => set({ storeSpaceId: id }),
+  setStoreId: (id) => set({ storeId: id }),
 
   setSchedule: (start, end) => set({ startSchedule: start, endSchedule: end }),
 


### PR DESCRIPTION
## 기획 및 구현한 내용

storeId, spaceId, chairId 저장해서 좌석 사용 가능하도록 했습니다

<!-- 구현한 기능에 관련된 기획을 서술 -->

## 변경사항
`reservationStore` 에 storeId, spaceId, chairId 저장 가능하도록 함

<!-- 주요 변경점 서술 -->

## 테스트 방법
1. yarn start 로 실행, 로그인
2. '카페' 탭 > '손수민가게추가' 가게 클릭
3. 좌석, 스페이스 예약해봄
<!-- 구현된 내용을 테스트 할 방법을 자세히 서술 -->

## 구현 내용 (스크린샷 or gif)
<img width="415" alt="image" src="https://github.com/seat-checking/web-user/assets/80534651/2d3cc25b-967c-43f4-8989-9bd2cc34a461">

<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 or gif 등을 활용해 서술 -->

## 체크리스트

<!-- 본인이 체크해야될 사항들을 빠짐없이 기록하기 위한 것 -->
<!-- 확인된 부분들에 체크표시하여 확인했다는 사실을 알려줌 -->

- [ ] 프로젝트의 코드 컨벤션과 스타일을 따름.
- [ ] 이슈 상태를 업데이트 함.
